### PR TITLE
Get working on ghc-7.7.20130908.

### DIFF
--- a/diagrams-contrib.cabal
+++ b/diagrams-contrib.cabal
@@ -40,7 +40,7 @@ library
                        Diagrams.TwoD.Path.Metafont.Parser
                        Diagrams.TwoD.Path.Metafont.Types
                        Diagrams.TwoD.Path.Metafont.Internal
-  build-depends:       base >= 4.2 && < 4.7,
+  build-depends:       base >= 4.2 && < 4.8,
                        mtl >= 2.0 && < 2.2,
                        containers > 0.4 && < 0.6,
                        split >= 0.2.1 && < 0.3,

--- a/src/Diagrams/Lens.hs
+++ b/src/Diagrams/Lens.hs
@@ -249,6 +249,7 @@ _mkFixedSeg = iso mkFixedSeg fromFixedSeg
 _straight :: Prism' (Segment Closed v) v
 _straight = prism' straight fromStraight
   where
+    fromStraight :: Segment c a -> Maybe a
     fromStraight (Linear (OffsetClosed x)) = Just x
     fromStraight _ = Nothing
 
@@ -257,6 +258,7 @@ _straight = prism' straight fromStraight
 _bezier3 :: Prism' (Segment Closed v) (v, v, v)
 _bezier3 = prism' (\(c1, c2, c3) -> bezier3 c1 c2 c3) fromBezier3
   where
+    fromBezier3 :: Segment c a -> Maybe (a, a, a)
     fromBezier3 (Cubic c1 c2 (OffsetClosed c3)) = Just (c1, c2, c3)
     fromBezier3 _ = Nothing
 

--- a/src/Diagrams/TwoD/Sunburst.hs
+++ b/src/Diagrams/TwoD/Sunburst.hs
@@ -34,6 +34,7 @@ import           Data.Foldable (foldMap)
 import           Data.Default.Class
 
 import           Diagrams.Prelude hiding (radius)
+import           Diagrams.TwoD.Arc (annularWedge)
 
 data SunburstOpts
   = SunburstOpts


### PR DESCRIPTION
I make no guarantees about 7.8.

Changes:
- allow base 4.7
- add two type signatures that ghc couldn't infer
  (http://ghc.haskell.org/trac/ghc/ticket/5678)
- import annularWedge (I don't understand how this worked before)
