### PR TITLE
primeLayout: rewrite to avoid iterated transformations

### DIFF
--- a/src/Diagrams/TwoD/Factorization.hs
+++ b/src/Diagrams/TwoD/Factorization.hs
@@ -64,9 +64,8 @@ primeLayout _ 2 d
                         # centerX
 primeLayout colors p d
   = (mconcat $
-       iterateN (fromIntegral p)
-         (rotateBy (1/fromIntegral p))
-         (d # translateY r)
+       map (\n -> d # translateY r # rotateBy
+              (fromIntegral n/fromIntegral p)) [0..p-1]
     )
     <>
     colorBars colors p poly


### PR DESCRIPTION
iterated calls to transformations tend to be slow.  This is especially notable in the Poster.hs benchmark, which sees about a 30% speedup (on my system) with this change.  Also see the note and `squares'` in diagrams-bench:/Rotations.hs.

Ideally calling iterateN on transformations should be much faster, but I think that may require significant changes to the current Transform type.
