### PR TITLE
Metafont bugfix

### DIFF
--- a/src/Diagrams/TwoD/Path/Metafont.hs
+++ b/src/Diagrams/TwoD/Path/Metafont.hs
@@ -2,8 +2,20 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TemplateHaskell #-}
 
--- | Metafont allows declaring Diagrams Paths using Donald Knuth's MetaFont syntax.
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Diagrams.TwoD.Path.Metafont
+-- Copyright   :  (c) 2013 Daniel Bergey
+-- License     :  BSD-style (see LICENSE)
+-- Maintainer  :  bergey@alum.mit.edu
+--
+-- Define Diagrams Paths by specifying points and
+-- optionally directions and tension.  Calculate control points to
+-- maintain smooth curvature at each point, following rules
+-- implemented in Donald Knuth's /Metafont/.
+--
 --  This module is intended to be imported qualified.
+-----------------------------------------------------------------------------
 module Diagrams.TwoD.Path.Metafont
        (
              module  Diagrams.TwoD.Path.Metafont.Combinators
@@ -24,9 +36,9 @@ import Diagrams.TwoD.Path.Metafont.Internal
 import Diagrams.TwoD.Path.Metafont.Combinators
 import Diagrams.TwoD.Path.Metafont.Parser
 
--- | MF.fromString is the primary interface to the MetaFont library.
---  It takes a ByteString in MetaFont syntax, and attempts to return a
---  TrailLike.
+-- | MF.fromString parses a Text value in MetaFont syntax, and
+-- attempts to return a TrailLike.  Only a subset of Metafont is
+-- supported; see the tutorial for details.
 fromString :: (TrailLike t, V t ~ R2) => Text -> Either ParseError t
 fromString s = case parse metafontParser "" s of
   (Left err) -> Left err -- with different type
@@ -35,7 +47,7 @@ fromString s = case parse metafontParser "" s of
 -- | fromStrings takes a list of MetaFont strings, and returns either
 --  all errors, or, if there are no parsing errors, a TrailLike for
 --  each string.  fromStrings is provided as a convenience because the
---  MetaFont &-join is not supported.  mconcat on the TrailLike is
+--  MetaFont &-join is not supported.  'mconcat' ('<>') on the TrailLike is
 --  equivalent, with clearer semantics.
 fromStrings :: (TrailLike t, V t ~ R2) => [Text] -> Either [ParseError] [t]
 fromStrings ss = case partitionEithers . map fromString $ ss of

--- a/src/Diagrams/TwoD/Path/Metafont/Combinators.hs
+++ b/src/Diagrams/TwoD/Path/Metafont/Combinators.hs
@@ -1,6 +1,16 @@
 {-# LANGUAGE TypeFamilies #-}
 
-module Diagrams.TwoD.Path.Metafont.Combinators where
+-- | Combinators to allow writing Metafont-style paths embedded in
+-- Haskell, with the usual Diagrams types for points and directions.
+
+module Diagrams.TwoD.Path.Metafont.Combinators
+       (
+           (.-), (-.), (.--.)
+       , endpt, cyclePath
+       , simpleJoin -- is this actually needed?
+       , tension, tensions, controls
+       , leaving, arriving
+       ) where
 
 import Diagrams.Prelude
 import Diagrams.TwoD.Path.Metafont.Types
@@ -8,10 +18,8 @@ import Diagrams.TwoD.Path.Metafont.Types
 -- internal alias to keep the signatures readable
 type Join = PathJoin (Maybe PathDir) (Maybe BasicJoin)
 
-
 -- | /point/ @.-@ /join/ @-.@ /path/ adds /point/ to the
 -- left end of the metafont /path/, connected by /join/.
-
 (.-) :: P2 -> MFPathData J -> MFPathData P
 (.-) = MFPathPt
 

--- a/src/Diagrams/TwoD/Path/Metafont/Parser.hs
+++ b/src/Diagrams/TwoD/Path/Metafont/Parser.hs
@@ -104,6 +104,8 @@ mfs = MFS <$> pt <*> join <*> lookAhead pt
 matches :: Stream s m t => ParsecT s u m a -> ParsecT s u m Bool
 matches p = option False (p *> return True)
 
+-- | Parse a 'Text' value in Metafont syntax, as destribed in /The
+-- METAFONTbook/.
 metafontParser :: Parser (MFPath (Maybe PathDir) BasicJoin)
 metafontParser = do
   ss <- many1 (try mfs)

--- a/src/Diagrams/TwoD/Path/Metafont/Types.hs
+++ b/src/Diagrams/TwoD/Path/Metafont/Types.hs
@@ -11,16 +11,22 @@ import Data.Semigroup
 
 import Diagrams.TwoD.Types
 
+-- | A @PathJoin@ specifies the directions at both ends of a segment,
+-- and a join which describes the control points explicitly or implicitly.
 data PathJoin d j = PJ { _d1 :: d, _j :: j, _d2 :: d }
   deriving (Functor, Show)
 
 makeLenses ''PathJoin
 
+-- | A direction can be specified at any point of a path.  A /curl/
+-- should only be specified at the endpoints.  The endpoints default
+-- to curl 1 if not set.
 data PathDir
   = PathDirCurl Curl
   | PathDirDir  Dir
     deriving Show
 
+-- | A predicate to determine the constructor used.
 isCurl :: PathDir -> Bool
 isCurl (PathDirDir _) = False
 isCurl (PathDirCurl _) = True
@@ -30,6 +36,11 @@ type Dir  = R2
 
 type BasicJoin = Either TensionJoin ControlJoin
 
+-- | Higher /Tension/ brings the path closer to a straight line
+-- between segments.  Equivalently, it brings the control points
+-- closer to the endpoints.  @TensionAmt@ introduces a fixed tension.
+-- @TensionAtLeast@ introduces a tension which will be increased if by
+-- so doing, an inflection point can be eliminated.
 data Tension
   = TensionAmt Double
   | TensionAtLeast Double
@@ -39,34 +50,51 @@ getTension :: Tension -> Double
 getTension (TensionAmt t)     = t
 getTension (TensionAtLeast t) = t
 
+-- | Two tensions and two directions completely determine the control
+-- points of a segment.
 data TensionJoin = TJ { _t1 :: Tension, _t2 :: Tension }
                  deriving Show
 
+-- | The two intermediate control points of a segment, specified directly.
 data ControlJoin = CJ { _c1 :: P2, _c2 :: P2 }
                  deriving Show
 
 makeLenses ''TensionJoin
 makeLenses ''ControlJoin
 
-data MetafontPath = MetafontPath Bool (MFPathData P2)
-                                           
 data P
 data J
 
+-- | @MFPathData@ is the type manipulated by the metafont combinators.
 data MFPathData a where
   MFPathCycle:: MFPathData P
   MFPathEnd  :: P2 -> MFPathData P
   MFPathPt   :: P2 -> MFPathData J -> MFPathData P
   MFPathJoin :: PathJoin (Maybe PathDir) (Maybe BasicJoin) -> MFPathData P -> MFPathData J
 
+-- | @MetafontSegment@ is used internally in solving the metafont
+-- equations.  It represents a segment with two known endpoints, and a
+-- /join/, which may be specified in various ways.
 data MetafontSegment d j = MFS { _x1 :: P2, _pj :: (PathJoin d j), _x2 :: P2 }
                          deriving (Functor, Show)
 
+-- | @MFPath@ is the type used internally in solving the metafont
+-- equations.  The direction and join types are progressively refined
+-- until all control points are known.  The @loop@ flag affects both
+-- the equations to be solved and the type of 'Trail' in the result.
+-- If constructing an @MFPath@ in new code, the responsibility rests
+-- on the user to ensure that successive @MetafontSegment@s share an
+-- endpoint.  If this is not true, the result is undefined.
 data MFPath d j = MFP { _loop :: Bool, _segs :: [MetafontSegment d j] }
                 deriving Show
 
+-- | MFP is a type synonym to clarify signatures in Metafont.Internal.
+-- Note that the type permits segments which are \"overspecified\",
+-- having one or both directions specified, and also a 'ControlJoin'.
+-- In this case, "Metafont.Internal" ignores the directions.
 type MFP = MFPath (Maybe PathDir) BasicJoin
 
+-- | MFS is a type synonym to clarify signatures in "Metafont.Internal".
 type MFS = MetafontSegment (Maybe PathDir) BasicJoin
 
 makeLenses ''MetafontSegment


### PR DESCRIPTION
My QuickCheck code isn't ready to merge, and should probably go in `diagrams-test` anyway.  But the bugs I found with QuickCheck should be fixed before 1.0, I think.  Most of these are pretty obnoxious---partial functions in the solver that don't work on empty lists or the `Right` side of at `Either` getting called on inappropriate inputs, so crash at runtime.  In other news, QuickCheck is awesome.

If you want to look at the QuickCheck tests, they're in the [metafont-quickcheck branch](https://github.com/diagrams/diagrams-contrib/blob/metafont-quickcheck/tests/Diagrams/TwoD/Path/MetaFont/Quickcheck.hs)

The final patch adds more docs, for any poor soul (eg, future me) who needs to debug `Metafont.Internal`.
