### PR TITLE
updated the upper bounds of the .cabal constraints for 'semigroups' package

### DIFF
--- a/diagrams-contrib.cabal
+++ b/diagrams-contrib.cabal
@@ -61,7 +61,7 @@ library
                        parsec >= 3.1 && < 3.2,
                        text >= 0.11 && < 1.2,
                        data-default-class < 0.1,
-                       semigroups >= 0.3.4 && < 0.13
+                       semigroups >= 0.3.4 && < 0.14
   hs-source-dirs:      src
   default-language:    Haskell2010
 


### PR DESCRIPTION
from: "< 0.13" to "< 0.14"

diagrams-core already has "< 0.14" and the "< 0.13" constraint  causes some packages to break (i.e. conduit)
