### PR TITLE
diagrams-contrib.cabal: allow QuickCheck-2.7

### DIFF
--- a/diagrams-contrib.cabal
+++ b/diagrams-contrib.cabal
@@ -75,7 +75,7 @@ test-suite turtle-tests
   other-modules:       Diagrams.TwoD.Path.Turtle.Tests
 
   build-depends:       HUnit                      >= 1.2 && < 1.3,
-                       QuickCheck                 >= 2.4 && < 2.7,
+                       QuickCheck                 >= 2.4 && < 2.8,
                        containers                 >= 0.3 && < 0.6,
                        test-framework             >= 0.4 && < 0.9,
                        test-framework-hunit       >= 0.2 && < 0.4,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
