### PR TITLE
Discuss - drop support for GHC-7.6?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: haskell
 env:
   matrix:
     - HPVER=2014.2.0.0 CABALVER=1.18
-    - GHCVER=7.4.2 CABALVER=1.18
     - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.2 CABALVER=1.22
     - GHCVER=head CABALVER=head
@@ -12,7 +11,6 @@ env:
 
 matrix:
   allow_failures:
-    - env: GHCVER=7.4.2 CABALVER=1.18
     - env: GHCVER=head CABALVER=head
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: haskell
 
 env:
   matrix:
-    - HPVER=2013.2.0.0 CABALVER=1.18
     - HPVER=2014.2.0.0 CABALVER=1.18
     - GHCVER=7.4.2 CABALVER=1.18
-    - GHCVER=7.6.3 CABALVER=1.18
     - GHCVER=7.8.4 CABALVER=1.18
     - GHCVER=7.10.2 CABALVER=1.22
     - GHCVER=head CABALVER=head


### PR DESCRIPTION
Building on 7.6 has been impossible since
71f6539c300c55dc7f7439bcb582d32c0b54fcdc which added a dependency on
cubicbezier, which requires containers >= 0.5.3, whereas GHC-7.6 has
template-haskell built against containers 0.5.0.

Are folks OK dropping 7.6 now?

@kuribas - Is it possible for `cubicbezier` to support `containers-0.5.0`?  How hard would it be?

Tangentially, we should probably restrict our travis builds to `template-haskell installed`.  The [failed builds here](https://travis-ci.org/diagrams/diagrams-contrib/jobs/93558967) try to rebuild `template-haskell` with newer `containers`, which I doubt is ever an acceptable solution.