### PR TITLE
Adapt Metafont to NonEmpty API change in diagrams-solve

### DIFF
--- a/src/Diagrams/TwoD/Path/Metafont/Internal.hs
+++ b/src/Diagrams/TwoD/Path/Metafont/Internal.hs
@@ -30,6 +30,9 @@ import           Data.Maybe
 import           Diagrams.Prelude                  hiding (view)
 import           Diagrams.Solve.Tridiagonal
 
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NE
+
 import           Diagrams.TwoD.Path.Metafont.Types
 
 
@@ -191,7 +194,7 @@ solveLoop ss = zipWith3 setDirs ss thetas phis where
 --   This is a system of (length ss) equations.  The first element of
 --   loopDirs ss is θ for the starting point of the first segment of ss.
 loopDirs :: RealFloat n => [MFS n] -> [n]
-loopDirs ss = solveCyclicTriDiagonal lower diag upper products ll ur where
+loopDirs ss = NE.toList $ solveCyclicTriDiagonal (NE.fromList lower) (NE.fromList diag) (NE.fromList upper) (NE.fromList products) ll ur where
   (lower, diag, upper, products, ll, ur) = loopEqs ss
 
 -- | Calculate the coefficients for the loop case, in the
@@ -256,11 +259,11 @@ psi (l,r) = normalizeTurns t where
 -- done by lineEqs and solveTriDiagonal, but lineDirs handles the separate cases
 -- of an empty list, and lists of length one.  See mf.web ¶ 280.
 lineDirs :: RealFloat n => [MFS n] -> [n]
-lineDirs ss | length ss > 1 = solveTriDiagonal lower diag upper products where
+lineDirs ss | length ss > 1 = NE.toList $ solveTriDiagonal (NE.fromList lower) (NE.fromList diag) (NE.fromList upper) (NE.fromList products) where
   (lower, diag, upper, products) = lineEqs ss
 lineDirs [] = []
 lineDirs [s] | leftCurl s && rightCurl s = [0, 0] where
-lineDirs [s] | rightCurl s = solveTriDiagonal [a] [1,c] [0] [normalizeTurns t, r] where
+lineDirs [s] | rightCurl s = NE.toList $ solveTriDiagonal (a :| []) (1 :| [c]) (0 :| []) (normalizeTurns t :| [r]) where
   (a,c,r) = solveOneSeg s
   (PathDirDir d) = s^.pj.d1.to fromJust
   t = view turn $ angleBetweenDirs d (direction $ s^.x2 .-. s^.x1)


### PR DESCRIPTION
Related: diagrams/diagrams-lib#376

## Summary

`diagrams-solve` commit `55f97904` (post-`v0.2`, 2026-06-04) changed `solveTriDiagonal` and `solveCyclicTriDiagonal` to accept and return `NonEmpty` instead of plain lists. This PR updates the call sites in `Diagrams.TwoD.Path.Metafont.Internal`.

Changes in `src/Diagrams/TwoD/Path/Metafont/Internal.hs`:
- Import `Data.List.NonEmpty`
- Wrap list arguments with `NE.fromList`, unwrap results with `NE.toList` in `loopDirs` and the `length ss > 1` branch of `lineDirs`
- Use `:|` literal syntax for the single-element `lineDirs [s]` call

## Test plan

- [ ] `stack build` succeeds against HEAD of `diagrams-solve` (commit `55f97904`)
- [ ] `stack test` passes
- [ ] Metafont path rendering produces correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)